### PR TITLE
[fix] Create storage widget will suppress RuntimeError if pointer is not valid

### DIFF
--- a/plutus_terminal/ui/widgets/positions_table.py
+++ b/plutus_terminal/ui/widgets/positions_table.py
@@ -252,10 +252,15 @@ class PositionsTableView(QTableView):
             pnl_details = self._exchange.calculate_pnl(data, current_price)
 
             trade_direction = data["trade_direction"]
-            pnl_widget = ui_utils.get_stored_widget(
+
+            pnl_widget = ui_utils.get_or_create_stored_widget(
+                PnlBreakdown,
                 self._pnl_widgets,
                 data["pair"],
                 trade_direction,
+                position=data,
+                exchange=self._exchange,
+                parent=self,
             )
             if pnl_widget is None or not isinstance(pnl_widget, PnlBreakdown):
                 return


### PR DESCRIPTION
While trying to delete the widget if the pointer is not valid anymore, Pyside will throw a RuntimeError, to avoid issues, this error will be suppressed, and the function will return the new widget.