### PR TITLE
[fix] Fix Foxify Funded order size for Challenge level

### DIFF
--- a/plutus_terminal/core/exchange/foxify/funded_exchange.py
+++ b/plutus_terminal/core/exchange/foxify/funded_exchange.py
@@ -49,9 +49,16 @@ class FoxifyFundedExchange(FoxifyExchange):
             trader_challenge,
         ).call()
 
-        min_deposit_stable = chanllenge_configs[13] / 10**foxify_utils.USDC_DECIMAL_PLACES
         self._min_leverage = chanllenge_configs[11] / basis_point
         self._max_leverage = chanllenge_configs[12] / basis_point
+
+        # If trader is on challenge get min deposit from min_deposit_stable
+        # Otherwise get it from funding value
+        if trader_challenge == 1:
+            min_deposit_stable = chanllenge_configs[14] / 10**foxify_utils.USDC_DECIMAL_PLACES
+        else:
+            min_deposit_stable = chanllenge_configs[13] / 10**foxify_utils.USDC_DECIMAL_PLACES
+
         self._min_order_size = Decimal(chanllenge_configs[9] / basis_point) * Decimal(
             min_deposit_stable,
         )


### PR DESCRIPTION
The logic was looking for the funding value to decide the min/max order size, but the challenge level does not have any funding value, in this case, look at the minimum deposit value to calculate the min order size.
Closes #25