### PR TITLE
[fix] Calculate min and max order for foxify based on starting capital

### DIFF
--- a/plutus_terminal/core/exchange/foxify/funded_exchange.py
+++ b/plutus_terminal/core/exchange/foxify/funded_exchange.py
@@ -51,21 +51,21 @@ class FoxifyFundedExchange(FoxifyExchange):
             trader_challenge,
         ).call()
 
+        # Calculate min and max leverage
         self._min_leverage = chanllenge_configs[11] / basis_point
         self._max_leverage = chanllenge_configs[12] / basis_point
 
-        # If trader is on challenge get min deposit from min_deposit_stable
-        # Otherwise get it from funding value
-        if trader_challenge == 1:
-            min_deposit_stable = chanllenge_configs[14] / 10**foxify_utils.USDC_DECIMAL_PLACES
-        else:
-            min_deposit_stable = chanllenge_configs[13] / 10**foxify_utils.USDC_DECIMAL_PLACES
+        # Calculate min and max order size
+        trader_starting_capital = (
+            await self._funded_trader_contract.functions.startingCapital().call()
+            / 10**foxify_utils.USDC_DECIMAL_PLACES
+        )
 
         self._min_order_size = Decimal(chanllenge_configs[9] / basis_point) * Decimal(
-            min_deposit_stable,
+            trader_starting_capital,
         )
         self._max_order_size = Decimal(chanllenge_configs[10] / basis_point) * Decimal(
-            min_deposit_stable,
+            trader_starting_capital,
         )
 
         self._trader = await FoxifyFundedTrader.create(


### PR DESCRIPTION
The starting capital needs to be used in case the user rollover more funds in their funded account. Closes #46.