### PR TITLE
Use getAllNews for Phoenix history when API key is available

### DIFF
--- a/plutus_terminal/core/news/phoenix_news.py
+++ b/plutus_terminal/core/news/phoenix_news.py
@@ -140,13 +140,33 @@ class PhoenixNews(NewsFetcher):
             list[NewsData]: List of old news. This list is expected to be ordered.
             from latest to oldest.
         """
-        request_url = f"https://api.phoenixnews.io/getLastNews?limit={limit}"
+        request_url, request_headers = self._get_historical_news_request(limit)
         async with AsyncClient() as client:
-            response = await client.get(request_url)
+            response = await client.get(request_url, headers=request_headers)
         response.raise_for_status()
         data = response.json()
         list_news = [self.format_news(news) for news in data]
         return list_news[::-1]
+
+    def _get_historical_news_request(self, limit: int) -> tuple[str, dict[str, str]]:
+        """Build the Phoenix historical news request URL and headers."""
+        request_url = f"https://api.phoenixnews.io/getLastNews?limit={limit}"
+
+        try:
+            phoenix_api_key = keyring_manager.get_news_source_api_key(
+                self.NEWS_SERVICE_NAME,
+                pass_guard=self._pass_guard,
+            )
+        except KeyringPasswordNotFoundError:
+            return request_url, {}
+
+        if not phoenix_api_key:
+            return request_url, {}
+
+        return (
+            f"https://api.phoenixnews.io/getAllNews?limit={limit}",
+            {"x-api-key": phoenix_api_key},
+        )
 
     def format_news(self, news_message: dict) -> NewsData:  # noqa: C901, PLR0915
         """Format given news.

--- a/tests/news/test_phoenix_news_updates.py
+++ b/tests/news/test_phoenix_news_updates.py
@@ -3,13 +3,102 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
+from typing import Self
+from unittest.mock import patch
 
+from plutus_terminal.core.exceptions import KeyringPasswordNotFoundError
 from plutus_terminal.core.news.phoenix_news import PhoenixNews
 
 
 class TestPhoenixNewsUpdates:
     """Tests for Phoenix update message parsing."""
+
+    def test_fetch_old_news_uses_get_all_news_when_api_key_exists(self) -> None:
+        """Historical Phoenix fetches should use the subscriber endpoint with the API key."""
+        phoenix_news = PhoenixNews(object())
+        captured_requests: list[tuple[str, dict[str, str]]] = []
+
+        class _ResponseStub:
+            def raise_for_status(self) -> None:
+                """Pretend the HTTP response succeeded."""
+
+            def json(self) -> list[dict[str, object]]:
+                """Return an empty news payload."""
+                return []
+
+        class _AsyncClientStub:
+            async def __aenter__(self) -> Self:
+                """Enter the async client context."""
+                return self
+
+            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+                """Exit the async client context."""
+
+            async def get(self, url: str, headers: dict[str, str]) -> _ResponseStub:
+                """Capture the request and return a stub response."""
+                captured_requests.append((url, headers))
+                return _ResponseStub()
+
+        with (
+            patch(
+                "plutus_terminal.core.news.phoenix_news.keyring_manager.get_news_source_api_key",
+                return_value="phoenix-api-key",
+            ),
+            patch(
+                "plutus_terminal.core.news.phoenix_news.AsyncClient",
+                return_value=_AsyncClientStub(),
+            ),
+        ):
+            assert asyncio.run(phoenix_news.fetch_old_news(50)) == []
+
+        assert captured_requests == [
+            (
+                "https://api.phoenixnews.io/getAllNews?limit=50",
+                {"x-api-key": "phoenix-api-key"},
+            ),
+        ]
+
+    def test_fetch_old_news_uses_public_endpoint_without_api_key(self) -> None:
+        """Historical Phoenix fetches should keep using the public endpoint without a key."""
+        phoenix_news = PhoenixNews(object())
+        captured_requests: list[tuple[str, dict[str, str]]] = []
+
+        class _ResponseStub:
+            def raise_for_status(self) -> None:
+                """Pretend the HTTP response succeeded."""
+
+            def json(self) -> list[dict[str, object]]:
+                """Return an empty news payload."""
+                return []
+
+        class _AsyncClientStub:
+            async def __aenter__(self) -> Self:
+                """Enter the async client context."""
+                return self
+
+            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+                """Exit the async client context."""
+
+            async def get(self, url: str, headers: dict[str, str]) -> _ResponseStub:
+                """Capture the request and return a stub response."""
+                captured_requests.append((url, headers))
+                return _ResponseStub()
+
+        with (
+            patch(
+                "plutus_terminal.core.news.phoenix_news.keyring_manager.get_news_source_api_key",
+                side_effect=KeyringPasswordNotFoundError("missing"),
+            ),
+            patch(
+                "plutus_terminal.core.news.phoenix_news.AsyncClient",
+                return_value=_AsyncClientStub(),
+            ),
+        ):
+            assert asyncio.run(phoenix_news.fetch_old_news(25)) == []
+
+        assert captured_requests == [("https://api.phoenixnews.io/getLastNews?limit=25", {})]
 
     def test_format_news_keeps_inline_ai_fields_on_historical_news(self) -> None:
         """Historical Phoenix news should keep inline AI summary and important fields."""


### PR DESCRIPTION
- Switch historical fetch to `getAllNews` with `x-api-key` when keyring returns a key
- Fall back to `getLastNews` without headers when no key/password is available
- Add tests covering both endpoint-selection paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News fetching system now intelligently routes requests through different endpoints based on API credential availability, improving data access options.

* **Bug Fixes**
  * Enhanced error handling for missing authentication credentials with graceful fallback behavior to ensure continued functionality without interruption.

* **Tests**
  * Added comprehensive test cases verifying correct endpoint selection and request headers across authenticated and unauthenticated news retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->