### PR TITLE
Fix Orderly leverage limit syncing and preset controls

### DIFF
--- a/plutus_terminal/controller/ui_controller.py
+++ b/plutus_terminal/controller/ui_controller.py
@@ -225,15 +225,16 @@ class UIController(QObject):
             )
             return
         pair = self.current_exchange.format_pair_from_coin(coin)
+        pair_max_leverage = self.current_exchange.max_leverage_for_pair(pair)
         applied_leverage = self.app_config.leverage
         if leverage < self.current_exchange.min_leverage:
             Toast.show_message(
                 f"Leverage of {pair} is too low. Set minimum leverage: {self.current_exchange.min_leverage}x",
                 type_=ToastType.WARNING,
             )
-        elif leverage > self.current_exchange.max_leverage:
+        elif leverage > pair_max_leverage:
             Toast.show_message(
-                f"Leverage of {pair} is too high. Set maximum leverage: {self.current_exchange.max_leverage}x",
+                f"Leverage of {pair} is too high. Set maximum leverage: {pair_max_leverage}x",
                 type_=ToastType.WARNING,
             )
         elif applied_leverage != leverage:

--- a/plutus_terminal/controller/widgets/perps_trade_controller.py
+++ b/plutus_terminal/controller/widgets/perps_trade_controller.py
@@ -196,6 +196,9 @@ class PerpsTradeController(QObject):
         view = self._view()
         if view is None:
             return
+        view.set_max_leverage(
+            view.exchange.max_leverage_for_pair(self._ui_controller.current_pair),
+        )
         view.set_leverage_spin_value(self._ui_controller.app_config.leverage)
         self.refresh_trade_summary()
         view.update_leverage_buttons(self._ui_controller.app_config.leverage)
@@ -240,9 +243,15 @@ class PerpsTradeController(QObject):
         if view is None:
             return
         simplified_pair = view.exchange.format_simple_pair_from_pair(pair)
+        pair_max_leverage = view.exchange.max_leverage_for_pair(pair)
+        requested_leverage = self._ui_controller.app_config.leverage
         view.set_pair_text(simplified_pair)
+        view.set_max_leverage(pair_max_leverage)
         coin = view.exchange.format_coin_from_pair(pair)
-        await self._ui_controller.set_leverage(coin, self._ui_controller.app_config.leverage)
+        await self._ui_controller.set_leverage(coin, requested_leverage)
+        if self._ui_controller.app_config.leverage != requested_leverage:
+            view.set_leverage_spin_value(self._ui_controller.app_config.leverage)
+            view.update_leverage_buttons(self._ui_controller.app_config.leverage)
 
     def handle_exchange_changed(self) -> None:
         """Refresh widget state after exchange changes."""
@@ -252,7 +261,9 @@ class PerpsTradeController(QObject):
         view.set_exchange(self._ui_controller.current_exchange)
         view.populate_pairs_from_exchange()
         view.update_trade_buttons()
-        view.set_max_leverage(view.exchange.max_leverage)
+        current_pair = self._ui_controller.current_pair
+        view.set_pair_text(view.exchange.format_simple_pair_from_pair(current_pair))
+        view.set_max_leverage(view.exchange.max_leverage_for_pair(current_pair))
         view.set_leverage_spin_value(self._ui_controller.app_config.leverage)
         view.update_leverage_buttons(self._ui_controller.app_config.leverage)
         self.refresh_trade_summary()

--- a/plutus_terminal/core/config.py
+++ b/plutus_terminal/core/config.py
@@ -212,6 +212,7 @@ class AppConfig(QObject):
            trade_value_low (int)
            trade_value_medium (int)
            trade_value_high (int)
+           leverage_button_1..leverage_button_7 (int): leverage preset buttons
     """
 
     _instance: Self | None = None
@@ -224,7 +225,24 @@ class AppConfig(QObject):
     trade_value_low: int
     trade_value_medium: int
     trade_value_high: int
+    leverage_button_1: int
+    leverage_button_2: int
+    leverage_button_3: int
+    leverage_button_4: int
+    leverage_button_5: int
+    leverage_button_6: int
+    leverage_button_7: int
     current_account_id: int
+
+    LEVERAGE_BUTTON_FIELDS = (
+        "leverage_button_1",
+        "leverage_button_2",
+        "leverage_button_3",
+        "leverage_button_4",
+        "leverage_button_5",
+        "leverage_button_6",
+        "leverage_button_7",
+    )
 
     SERVICE_NAME = "plutus-terminal"
 
@@ -236,6 +254,13 @@ class AppConfig(QObject):
     trade_value_low_changed = Signal(int)
     trade_value_medium_changed = Signal(int)
     trade_value_high_changed = Signal(int)
+    leverage_button_1_changed = Signal(int)
+    leverage_button_2_changed = Signal(int)
+    leverage_button_3_changed = Signal(int)
+    leverage_button_4_changed = Signal(int)
+    leverage_button_5_changed = Signal(int)
+    leverage_button_6_changed = Signal(int)
+    leverage_button_7_changed = Signal(int)
     current_account_id_changed = Signal(int)
 
     # GUI Settings Signals
@@ -270,6 +295,7 @@ class AppConfig(QObject):
         "trade_value_low",
         "trade_value_medium",
         "trade_value_high",
+        *LEVERAGE_BUTTON_FIELDS,
     ]
 
     # Attach descriptors dynamically
@@ -303,6 +329,10 @@ class AppConfig(QObject):
     def _ensure_database(self) -> None:
         if not DATABASE_PATH.exists():
             create_database()
+            return
+        from plutus_terminal.core.db.models import ensure_trade_config_columns
+
+        ensure_trade_config_columns()
 
     def _load_services_for_account(self) -> None:
         current_id = self.gui_settings_service.get("current_account_id")
@@ -315,6 +345,11 @@ class AppConfig(QObject):
         trade = self._trade_service.load()
         for f in self._trade_fields:
             setattr(self, f"_{f}", getattr(trade, f))
+
+    @property
+    def leverage_button_values(self) -> list[int]:
+        """Return configured leverage preset button values."""
+        return [getattr(self, field_name) for field_name in self.LEVERAGE_BUTTON_FIELDS]
 
     @property
     def current_keyring_account(self) -> KeyringAccount:

--- a/plutus_terminal/core/db/models.py
+++ b/plutus_terminal/core/db/models.py
@@ -42,6 +42,13 @@ class TradeConfig(BaseModel):
     trade_value_low = IntegerField(default=250)
     trade_value_medium = IntegerField(default=500)
     trade_value_high = IntegerField(default=1000)
+    leverage_button_1 = IntegerField(default=2)
+    leverage_button_2 = IntegerField(default=5)
+    leverage_button_3 = IntegerField(default=10)
+    leverage_button_4 = IntegerField(default=20)
+    leverage_button_5 = IntegerField(default=25)
+    leverage_button_6 = IntegerField(default=50)
+    leverage_button_7 = IntegerField(default=100)
 
 
 class UserFilter(BaseModel):
@@ -81,6 +88,7 @@ class Web3RPC(BaseModel):
 def create_database() -> None:
     """Create database tables."""
     if DATABASE_PATH.exists():
+        ensure_trade_config_columns()
         return
     with DATABASE:
         DATABASE.create_tables(
@@ -92,3 +100,36 @@ def create_database() -> None:
                 Web3RPC,
             ],
         )
+    ensure_trade_config_columns()
+
+
+def ensure_trade_config_columns() -> None:
+    """Backfill new TradeConfig columns for existing local databases."""
+    trade_config_table_name = "tradeconfig"
+    if not DATABASE_PATH.exists() or not DATABASE.table_exists(trade_config_table_name):
+        return
+
+    column_defaults = {
+        "leverage_button_1": 2,
+        "leverage_button_2": 5,
+        "leverage_button_3": 10,
+        "leverage_button_4": 20,
+        "leverage_button_5": 25,
+        "leverage_button_6": 50,
+        "leverage_button_7": 100,
+    }
+    existing_columns = {
+        row[1]
+        for row in DATABASE.execute_sql(
+            f'PRAGMA table_info("{trade_config_table_name}")',
+        ).fetchall()
+    }
+
+    with DATABASE.atomic():
+        for column_name, default_value in column_defaults.items():
+            if column_name in existing_columns:
+                continue
+            DATABASE.execute_sql(
+                f'ALTER TABLE "{trade_config_table_name}" '
+                f'ADD COLUMN "{column_name}" INTEGER DEFAULT {default_value}',
+            )

--- a/plutus_terminal/core/exchange/base.py
+++ b/plutus_terminal/core/exchange/base.py
@@ -338,6 +338,10 @@ class ExchangeBase(ABC):
     def max_leverage(self) -> int:
         """Return max leverage."""
 
+    def max_leverage_for_pair(self, _pair: str) -> int:
+        """Return the effective max leverage for one pair."""
+        return self.max_leverage
+
     @property
     def account_info(self) -> dict[str, object]:
         """Return info to be added to account info widget."""

--- a/plutus_terminal/core/exchange/orderly/exchange.py
+++ b/plutus_terminal/core/exchange/orderly/exchange.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from decimal import Decimal
 import logging
+import re
 from typing import TYPE_CHECKING, Optional, Self
 
 from httpx import HTTPStatusError, RequestError, TimeoutException
@@ -54,6 +55,7 @@ LOGGER = logging.getLogger(__name__)
 _REQUIRED_ORDERLY_SECRETS = 3
 _NETWORK_SECRET_INDEX = 3
 _ORDERLY_KEY_PREFIX = "ed25519:"
+_LEVERAGE_RANGE_PATTERN = re.compile(r"between\s+(\d+)x\s+and\s+(\d+)x", re.IGNORECASE)
 _FALLBACK_MARKET_SYMBOLS = (
     "PERP_BTC_USDC",
     "PERP_ETH_USDC",
@@ -132,7 +134,10 @@ class OrderlyExchange(ExchangeBase):
             message_bus=self.message_bus,
         )
         self._trader = OrderlyTrader(self._private_rest_client, self._market_registry)
-        self._max_leverage = await self._fetch_max_leverage()
+        self._max_leverage = max(
+            await self._fetch_max_leverage(),
+            getattr(self._market_registry, "max_leverage", 0),
+        )
 
     @retry(
         retry=retry_if_exception_type(
@@ -247,8 +252,13 @@ class OrderlyExchange(ExchangeBase):
 
     @property
     def max_leverage(self) -> int:
-        """Return maximum leverage for the account."""
+        """Return the highest leverage exposed by current Orderly metadata."""
         return self._max_leverage
+
+    def max_leverage_for_pair(self, pair: str) -> int:
+        """Return the current Orderly leverage cap for a specific pair."""
+        market_rule = self._market_registry.get_rule_by_pair(pair)
+        return market_rule.max_leverage
 
     @property
     def min_order_size(self) -> Decimal:
@@ -298,16 +308,26 @@ class OrderlyExchange(ExchangeBase):
     async def set_leverage(self, coin: str, leverage: int) -> None:
         """Set leverage for a specific coin pair."""
         pair = self.format_pair_from_coin(coin)
-        max_for_pair = self._max_leverage_for_pair(pair)
+        max_for_pair = self.max_leverage_for_pair(pair)
         bounded = max(self.min_leverage, min(max_for_pair, leverage))
         symbol = self._market_registry.get_symbol_for_pair(pair)
-        await self.trader.set_leverage(symbol, bounded)
-        self.app_config.leverage = bounded
+        try:
+            await self.trader.set_leverage(symbol, bounded)
+        except TransactionFailedError as error:
+            fallback_max_leverage = _extract_max_leverage_from_error(error)
+            if fallback_max_leverage is None or fallback_max_leverage >= bounded:
+                raise
 
-    def _max_leverage_for_pair(self, pair: str) -> int:
-        """Resolve effective max leverage for a pair from account and market limits."""
-        market_rule = self._market_registry.get_rule_by_pair(pair)
-        return min(self.max_leverage, market_rule.max_leverage)
+            LOGGER.warning(
+                "Orderly rejected %s leverage=%sx; retrying with server limit=%sx",
+                pair,
+                bounded,
+                fallback_max_leverage,
+            )
+            self._market_registry.update_pair_max_leverage(pair, fallback_max_leverage)
+            bounded = max(self.min_leverage, min(fallback_max_leverage, leverage))
+            await self.trader.set_leverage(symbol, bounded)
+        self.app_config.leverage = bounded
 
     @asyncSlot()
     async def create_order(
@@ -533,13 +553,13 @@ class OrderlyExchange(ExchangeBase):
             payload = await self._private_rest_client.request_private("GET", "/v1/client/info")
         except Exception:
             LOGGER.exception("Failed to fetch max leverage from Orderly client info")
-            return 50
+            return 100
         max_leverage = payload.get("data", {}).get("max_leverage")
         if isinstance(max_leverage, int):
             return max_leverage
         if isinstance(max_leverage, str) and max_leverage:
             return int(max_leverage)
-        return 50
+        return 100
 
     def _resolve_attached_tp_sl_targets(
         self,
@@ -751,3 +771,11 @@ def _normalize_orderly_key(orderly_key: str) -> str:
     if normalized_key.startswith(_ORDERLY_KEY_PREFIX):
         return normalized_key
     return f"{_ORDERLY_KEY_PREFIX}{normalized_key}"
+
+
+def _extract_max_leverage_from_error(error: TransactionFailedError) -> int | None:
+    """Extract the server-reported max leverage from an Orderly error message."""
+    match = _LEVERAGE_RANGE_PATTERN.search(str(error))
+    if match is None:
+        return None
+    return int(match.group(2))

--- a/plutus_terminal/core/exchange/orderly/markets.py
+++ b/plutus_terminal/core/exchange/orderly/markets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal, InvalidOperation
 import logging
 from typing import TYPE_CHECKING
@@ -45,6 +45,11 @@ class OrderlyMarketRegistry:
         """Return all formatted terminal pairs available for trading."""
         return set(self._symbol_by_pair)
 
+    @property
+    def max_leverage(self) -> int:
+        """Return the highest leverage exposed by the current market metadata."""
+        return max((rule.max_leverage for rule in self._by_symbol.values()), default=100)
+
     def get_rule_by_pair(self, pair: str) -> OrderlyMarketRule:
         """Return rule for one terminal pair."""
         symbol = self._symbol_by_pair[pair]
@@ -57,6 +62,16 @@ class OrderlyMarketRegistry:
     def get_symbol_for_pair(self, pair: str) -> str:
         """Return orderly symbol for terminal pair."""
         return self._symbol_by_pair[pair]
+
+    def update_pair_max_leverage(self, pair: str, max_leverage: int) -> None:
+        """Override one pair max leverage using a server-confirmed limit."""
+        symbol = self._symbol_by_pair.get(pair)
+        if symbol is None:
+            return
+        market_rule = self._by_symbol.get(symbol)
+        if market_rule is None or market_rule.max_leverage == max_leverage:
+            return
+        self._by_symbol[symbol] = replace(market_rule, max_leverage=max_leverage)
 
     async def refresh(self, rest_client: OrderlyRestClient) -> None:
         """Refresh registry from `/v1/public/info` response."""
@@ -112,7 +127,7 @@ class OrderlyMarketRegistry:
                 quote_max=Decimal("999999999"),
                 quote_tick=Decimal("0.01"),
                 min_notional=Decimal("1"),
-                max_leverage=50,
+                max_leverage=100,
             )
             by_symbol[symbol] = rule
             symbol_by_pair[pair] = symbol
@@ -135,7 +150,7 @@ def _extract_max_leverage(row: dict[str, object]) -> int:
         return max_leverage
     if isinstance(max_leverage, str) and max_leverage:
         return int(max_leverage)
-    return 50
+    return 100
 
 
 def _build_market_rule(row: dict[str, object]) -> OrderlyMarketRule:

--- a/plutus_terminal/ui/widgets/config/perps_config.py
+++ b/plutus_terminal/ui/widgets/config/perps_config.py
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
 class PerpsConfig(QtWidgets.QWidget):
     """Widget to control perps configuration."""
 
+    _LEVERAGE_PRESET_SIGNAL_NAMES = (
+        "leverage_button_1_changed",
+        "leverage_button_2_changed",
+        "leverage_button_3_changed",
+        "leverage_button_4_changed",
+        "leverage_button_5_changed",
+        "leverage_button_6_changed",
+        "leverage_button_7_changed",
+    )
+
     def __init__(
         self,
         ui_controller: UIController,
@@ -57,8 +67,13 @@ class PerpsConfig(QtWidgets.QWidget):
         self._leverage_box_layout = QtWidgets.QGridLayout()
         self._leverage_label = QtWidgets.QLabel("Leverage:")
         self._leverage_spin = QtWidgets.QSpinBox()
+        self._pair_leverage_hint = QtWidgets.QLabel()
+        self._leverage_button_values_box = QtWidgets.QGroupBox("Leverage Buttons")
+        self._leverage_button_values_layout = QtWidgets.QGridLayout()
         self._leverage_group = QtWidgets.QButtonGroup()
         self._leverage_layout = QtWidgets.QHBoxLayout()
+        self._leverage_button_spins = [QtWidgets.QSpinBox() for _ in range(7)]
+        self._leverage_button_update = QtWidgets.QPushButton("Update Leverage Buttons")
         self._leverage_set_button = QtWidgets.QPushButton("Set Leverage for All Pairs")
 
         self._spin_config_map: dict[
@@ -113,29 +128,46 @@ class PerpsConfig(QtWidgets.QWidget):
 
         self._trade_values_update.setMinimumHeight(35)
 
-        for value in (2, 5, 10, 20, 25, 50):
-            button = QtWidgets.QRadioButton(str(value))
-            self._leverage_group.addButton(button)
-            self._leverage_group.setId(button, value)
-            self._leverage_layout.addWidget(button)
+        self._rebuild_leverage_buttons()
 
         self._leverage_spin.setMinimum(1)
         self._leverage_spin.setMaximum(self._ui_controller.current_exchange.max_leverage)
         self._leverage_spin.setValue(self._app_config.leverage)
+        self._pair_leverage_hint.setWordWrap(True)
+        self._update_pair_leverage_hint()
+        for spin_box, leverage_value in zip(
+            self._leverage_button_spins,
+            self._app_config.leverage_button_values,
+            strict=False,
+        ):
+            spin_box.setMinimum(1)
+            spin_box.setMaximum(1000)
+            spin_box.setValue(leverage_value)
 
         self._leverage_set_button.setMinimumHeight(35)
+        self._leverage_set_button.setToolTip(
+            "Stores the default leverage. Each pair still uses its own exchange limit.",
+        )
+        self._leverage_button_update.setMinimumHeight(35)
+        self._leverage_button_update.setToolTip(
+            "Preset buttons keep your custom values and always append the live exchange max.",
+        )
 
     def _connect_signals(self) -> None:
         """Connect signals."""
         self._ui_controller.exchange_changed.connect(self._on_new_exchange)
+        self._ui_controller.pair_changed.connect(self._on_pair_changed)
         self._tp_sl_update.clicked.connect(self._update_tp_sl)
         self._trade_values_update.clicked.connect(self._update_trade_values)
         self._leverage_group.buttonClicked.connect(self._set_leverage_button)
         self._leverage_spin.valueChanged.connect(self._update_leverage_buttons)
+        self._leverage_button_update.clicked.connect(self._update_leverage_button_values)
         self._leverage_set_button.clicked.connect(self._set_leverage)
 
         self._app_config.leverage_changed.connect(self._set_leverage_spin)
         self._app_config.leverage_changed.connect(self._update_leverage_buttons)
+        for signal_name in self._LEVERAGE_PRESET_SIGNAL_NAMES:
+            getattr(self._app_config, signal_name).connect(self._refresh_leverage_button_controls)
 
     def _setup_layout(self) -> None:
         """Configure layout."""
@@ -160,10 +192,19 @@ class PerpsConfig(QtWidgets.QWidget):
         self._trade_values_layout.addWidget(self._trade_values_update, 4, 0, 1, 2)
         self._trade_values_box.setLayout(self._trade_values_layout)
         self._advanced_box_layout.addWidget(self._trade_values_box)
+        for index, spin_box in enumerate(self._leverage_button_spins, start=1):
+            self._leverage_button_values_layout.addWidget(
+                QtWidgets.QLabel(f"Button {index}:"), index - 1, 0
+            )
+            self._leverage_button_values_layout.addWidget(spin_box, index - 1, 1)
+        self._leverage_button_values_layout.addWidget(self._leverage_button_update, 7, 0, 1, 2)
+        self._leverage_button_values_box.setLayout(self._leverage_button_values_layout)
+        self._advanced_box_layout.addWidget(self._leverage_button_values_box)
         self._leverage_box_layout.addWidget(self._leverage_label, 0, 0)
         self._leverage_box_layout.addWidget(self._leverage_spin, 0, 1)
-        self._leverage_box_layout.addLayout(self._leverage_layout, 1, 0, 1, 2)
-        self._leverage_box_layout.addWidget(self._leverage_set_button, 2, 0, 1, 2)
+        self._leverage_box_layout.addWidget(self._pair_leverage_hint, 1, 0, 1, 2)
+        self._leverage_box_layout.addLayout(self._leverage_layout, 2, 0, 1, 2)
+        self._leverage_box_layout.addWidget(self._leverage_set_button, 3, 0, 1, 2)
         self._leverage_box.setLayout(self._leverage_box_layout)
         self._advanced_box_layout.addWidget(self._leverage_box)
         self._advanced_bar.main_layout.addLayout(self._advanced_box_layout)
@@ -185,8 +226,9 @@ class PerpsConfig(QtWidgets.QWidget):
 
     def _update_leverage_buttons(self, leverage_value: int) -> None:
         """Update leverage buttons state based on leverage value."""
-        if leverage_value in {2, 5, 10, 20, 25, 50}:
-            self._leverage_group.button(int(leverage_value)).setChecked(True)
+        leverage_button = self._leverage_group.button(int(leverage_value))
+        if leverage_button is not None:
+            leverage_button.setChecked(True)
         else:
             button = self._leverage_group.checkedButton()
             if button:
@@ -201,6 +243,64 @@ class PerpsConfig(QtWidgets.QWidget):
             button (QtWidgets.QRadioButton): Leverage button clicked.
         """
         self._set_leverage_spin(self._leverage_group.id(button))
+
+    def _leverage_button_values(self) -> list[int]:
+        """Return normalized leverage button values including the live exchange max."""
+        button_values: list[int] = []
+        exchange_max_leverage = self._ui_controller.current_exchange.max_leverage
+        for leverage_value in [*self._app_config.leverage_button_values, exchange_max_leverage]:
+            bounded = max(
+                self._ui_controller.current_exchange.min_leverage,
+                min(exchange_max_leverage, int(leverage_value)),
+            )
+            if bounded not in button_values:
+                button_values.append(bounded)
+        return button_values
+
+    def _rebuild_leverage_buttons(self) -> None:
+        """Rebuild leverage preset buttons from config and exchange metadata."""
+        checked_id = self._leverage_group.checkedId()
+        self._leverage_group.setExclusive(False)
+        for button in list(self._leverage_group.buttons()):
+            self._leverage_group.removeButton(button)
+            self._leverage_layout.removeWidget(button)
+            button.deleteLater()
+        self._leverage_group.setExclusive(True)
+
+        for value in self._leverage_button_values():
+            button = QtWidgets.QRadioButton(str(value))
+            self._leverage_group.addButton(button)
+            self._leverage_group.setId(button, value)
+            self._leverage_layout.addWidget(button)
+
+        fallback_value = (
+            self._leverage_spin.value() if self._leverage_spin.value() > 0 else checked_id
+        )
+        if fallback_value > 0:
+            self._update_leverage_buttons(fallback_value)
+
+    def _refresh_leverage_button_controls(self, *_args: object) -> None:
+        """Refresh button controls after preset changes."""
+        for spin_box, leverage_value in zip(
+            self._leverage_button_spins,
+            self._app_config.leverage_button_values,
+            strict=False,
+        ):
+            spin_box.blockSignals(True)
+            spin_box.setValue(leverage_value)
+            spin_box.blockSignals(False)
+        self._rebuild_leverage_buttons()
+
+    def _update_leverage_button_values(self) -> None:
+        """Persist leverage preset button values."""
+        for field_name, spin_box in zip(
+            self._app_config.LEVERAGE_BUTTON_FIELDS,
+            self._leverage_button_spins,
+            strict=False,
+        ):
+            setattr(self._app_config, field_name, spin_box.value())
+        self._refresh_leverage_button_controls()
+        Toast.show_message("Leverage buttons updated", type_=ToastType.SUCCESS)
 
     @asyncSlot()
     async def _set_leverage(self) -> None:
@@ -230,6 +330,21 @@ class PerpsConfig(QtWidgets.QWidget):
         self._app_config.stop_loss = self._sl_spin.value()
         Toast.show_message("TP/SL values updated", type_=ToastType.SUCCESS)
 
+    def _update_pair_leverage_hint(self) -> None:
+        """Render the selected pair leverage cap for exchanges with per-pair limits."""
+        current_pair = self._ui_controller.current_pair
+        simple_pair = self._ui_controller.current_exchange.format_simple_pair_from_pair(
+            current_pair
+        )
+        max_leverage = self._ui_controller.current_exchange.max_leverage_for_pair(current_pair)
+        self._pair_leverage_hint.setText(
+            f"Current pair max: {simple_pair} {max_leverage}x. Each pair may use a different cap.",
+        )
+
+    def _on_pair_changed(self, _pair: str) -> None:
+        """Refresh the leverage hint after the selected pair changes."""
+        self._update_pair_leverage_hint()
+
     def _on_new_exchange(self) -> None:
         """Update widget on new exchange.
 
@@ -238,6 +353,7 @@ class PerpsConfig(QtWidgets.QWidget):
         """
         self.blockSignals(True)
         self._leverage_spin.setMaximum(self._ui_controller.current_exchange.max_leverage)
+        self._rebuild_leverage_buttons()
         # Update spin box values
         for spin, attr in self._spin_config_map.items():
             spin.blockSignals(True)
@@ -245,4 +361,6 @@ class PerpsConfig(QtWidgets.QWidget):
             spin.blockSignals(False)
 
         self._set_leverage_spin(self._app_config.leverage)
+        self._update_pair_leverage_hint()
+        self._refresh_leverage_button_controls()
         self.blockSignals(False)

--- a/plutus_terminal/ui/widgets/perps_trade.py
+++ b/plutus_terminal/ui/widgets/perps_trade.py
@@ -26,6 +26,16 @@ if TYPE_CHECKING:
 class PerpsTradeWidget(QtWidgets.QWidget):
     """Widget for Trading Perpetuals."""
 
+    _LEVERAGE_PRESET_SIGNAL_NAMES = (
+        "leverage_button_1_changed",
+        "leverage_button_2_changed",
+        "leverage_button_3_changed",
+        "leverage_button_4_changed",
+        "leverage_button_5_changed",
+        "leverage_button_6_changed",
+        "leverage_button_7_changed",
+    )
+
     def __init__(
         self,
         ui_controller: UIController,
@@ -104,7 +114,7 @@ class PerpsTradeWidget(QtWidgets.QWidget):
         self._setup_widgets()
         self._setup_layout()
 
-    def _setup_widgets(self) -> None:  # noqa: PLR0915
+    def _setup_widgets(self) -> None:
         """Configure widgets."""
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.top_bar.icon.setPixmap(
@@ -146,13 +156,11 @@ class PerpsTradeWidget(QtWidgets.QWidget):
         pair_layout.addWidget(self._pair_combo_box)
         self._pair_grp.setLayout(pair_layout)
 
-        for value in (2, 5, 10, 20, 25, 50):
-            button = QtWidgets.QRadioButton(str(value))
-            self._leverage_group.addButton(button)
-            self._leverage_group.setId(button, value)
-            self._leverage_btn_layout.addWidget(button)
+        self._rebuild_leverage_buttons()
         self._leverage_spin.setMinimum(1)
-        self._leverage_spin.setMaximum(self._exchange.max_leverage)
+        self._leverage_spin.setMaximum(
+            self._exchange.max_leverage_for_pair(self.current_pair_data())
+        )
         self._leverage_spin.setValue(self._app_config.leverage)
         self._leverage_spin.editingFinished.connect(
             lambda: self._controller.set_leverage_spin(
@@ -160,6 +168,8 @@ class PerpsTradeWidget(QtWidgets.QWidget):
             ),
         )
         self._update_leverage_buttons(self._leverage_spin.value())
+        for signal_name in self._LEVERAGE_PRESET_SIGNAL_NAMES:
+            getattr(self._app_config, signal_name).connect(self.refresh_leverage_buttons)
 
         self._trade_tab.setObjectName("tradeType")
         self._trade_tab.tabBar().setObjectName("tradeTypeTab")
@@ -367,7 +377,10 @@ class PerpsTradeWidget(QtWidgets.QWidget):
 
     def set_max_leverage(self, leverage_value: int) -> None:
         """Update the maximum allowed leverage."""
+        self._leverage_spin.blockSignals(True)
         self._leverage_spin.setMaximum(leverage_value)
+        self._leverage_spin.blockSignals(False)
+        self.refresh_leverage_buttons()
 
     def set_fee_value(self, text: str) -> None:
         """Render the fee summary text."""
@@ -404,8 +417,9 @@ class PerpsTradeWidget(QtWidgets.QWidget):
 
     def _update_leverage_buttons(self, leverage_value: int) -> None:
         """Update leverage buttons state based on leverage value."""
-        if leverage_value in {2, 5, 10, 20, 25, 50}:
-            self._leverage_group.button(int(leverage_value)).setChecked(True)
+        leverage_button = self._leverage_group.button(int(leverage_value))
+        if leverage_button is not None:
+            leverage_button.setChecked(True)
         else:
             button = self._leverage_group.checkedButton()
             if button:
@@ -416,6 +430,42 @@ class PerpsTradeWidget(QtWidgets.QWidget):
     def update_leverage_buttons(self, leverage_value: int) -> None:
         """Public wrapper for leverage button state updates."""
         self._update_leverage_buttons(leverage_value)
+
+    def _leverage_button_values(self) -> list[int]:
+        """Return normalized leverage button values including the live exchange max."""
+        button_values: list[int] = []
+        exchange_max_leverage = self._exchange.max_leverage
+        for leverage_value in [*self._app_config.leverage_button_values, exchange_max_leverage]:
+            bounded = max(
+                self._exchange.min_leverage, min(exchange_max_leverage, int(leverage_value))
+            )
+            if bounded not in button_values:
+                button_values.append(bounded)
+        return button_values
+
+    def _rebuild_leverage_buttons(self) -> None:
+        """Rebuild leverage preset buttons from config and exchange metadata."""
+        checked_id = self._leverage_group.checkedId()
+        self._leverage_group.setExclusive(False)
+        for button in list(self._leverage_group.buttons()):
+            self._leverage_group.removeButton(button)
+            self._leverage_btn_layout.removeWidget(button)
+            button.deleteLater()
+        self._leverage_group.setExclusive(True)
+
+        for value in self._leverage_button_values():
+            button = QtWidgets.QRadioButton(str(value))
+            self._leverage_group.addButton(button)
+            self._leverage_group.setId(button, value)
+            self._leverage_btn_layout.addWidget(button)
+
+        fallback_value = self.leverage_value() if self.leverage_value() > 0 else checked_id
+        if fallback_value > 0:
+            self._update_leverage_buttons(fallback_value)
+
+    def refresh_leverage_buttons(self) -> None:
+        """Refresh leverage buttons after config or exchange changes."""
+        self._rebuild_leverage_buttons()
 
     def _update_info(self) -> None:
         """Update frame info."""

--- a/tests/orderly/test_orderly_exchange_parity.py
+++ b/tests/orderly/test_orderly_exchange_parity.py
@@ -47,6 +47,7 @@ def _build_market_registry(
         pairs={"Crypto.BTC/USDC"},
         get_symbol_for_pair=Mock(return_value="PERP_BTC_USDC"),
         get_rule_by_pair=Mock(return_value=market_rule),
+        update_pair_max_leverage=Mock(),
     )
 
 
@@ -300,6 +301,20 @@ class OrderlyExchangeParityTests(unittest.IsolatedAsyncioTestCase):
         trader.set_leverage.assert_awaited_once_with("PERP_BTC_USDC", 20)
         assert app_config.leverage == 20
 
+    async def test_set_leverage_uses_pair_limit_when_global_limit_is_lower(self) -> None:
+        """Honor Orderly market leverage metadata instead of a stale lower global cap."""
+        # Arrange
+        app_config = _build_app_config()
+        trader = SimpleNamespace(set_leverage=AsyncMock())
+        exchange = _build_exchange(app_config=app_config, trader=trader, max_leverage=10)
+
+        # Act
+        await exchange.set_leverage("BTC", 100)
+
+        # Assert
+        trader.set_leverage.assert_awaited_once_with("PERP_BTC_USDC", 20)
+        assert app_config.leverage == 20
+
     async def test_set_leverage_keeps_existing_config_when_the_request_fails(self) -> None:
         """Do not mutate local leverage config when Orderly rejects the update."""
         # Arrange
@@ -314,6 +329,35 @@ class OrderlyExchangeParityTests(unittest.IsolatedAsyncioTestCase):
             await exchange.set_leverage("BTC", 100)
 
         assert app_config.leverage == 5
+
+    async def test_set_leverage_retries_with_server_reported_pair_maximum(self) -> None:
+        """Retry with the server limit when Orderly rejects stale market metadata."""
+        # Arrange
+        app_config = _build_app_config()
+        market_registry = _build_market_registry(max_leverage=100)
+        trader = SimpleNamespace(
+            set_leverage=AsyncMock(
+                side_effect=[
+                    TransactionFailedError("[-1005] Leverage must be between 1x and 50x."),
+                    None,
+                ],
+            ),
+        )
+        exchange = _build_exchange(
+            app_config=app_config,
+            market_registry=market_registry,
+            trader=trader,
+            max_leverage=100,
+        )
+
+        # Act
+        await exchange.set_leverage("BTC", 100)
+
+        # Assert
+        assert trader.set_leverage.await_args_list[0].args == ("PERP_BTC_USDC", 100)
+        assert trader.set_leverage.await_args_list[1].args == ("PERP_BTC_USDC", 50)
+        market_registry.update_pair_max_leverage.assert_called_once_with("Crypto.BTC/USDC", 50)
+        assert app_config.leverage == 50
 
     async def test_create_order_refreshes_orders_positions_and_emits_info_message(self) -> None:
         """Refresh caches after successful order creation and notify the user."""

--- a/tests/orderly/test_orderly_trade_widget_parity.py
+++ b/tests/orderly/test_orderly_trade_widget_parity.py
@@ -15,6 +15,9 @@ from PySide6 import QtCore, QtWidgets
 from plutus_terminal.core.types_ import PerpsTradeDirection, PerpsTradeType
 from plutus_terminal.ui.widgets.perps_trade import PerpsTradeWidget
 
+_BTC_PAIR_MAX_LEVERAGE = 25
+_ETH_PAIR_MAX_LEVERAGE = 50
+
 
 class _MessageBus(QtCore.QObject):
     """Minimal signal-only message bus for widget tests."""
@@ -28,7 +31,15 @@ class _AppConfig(QtCore.QObject):
 
     trade_value_high_changed = QtCore.Signal()
     trade_value_low_changed = QtCore.Signal()
+    trade_value_medium_changed = QtCore.Signal()
     trade_value_lowest_changed = QtCore.Signal()
+    leverage_button_1_changed = QtCore.Signal(int)
+    leverage_button_2_changed = QtCore.Signal(int)
+    leverage_button_3_changed = QtCore.Signal(int)
+    leverage_button_4_changed = QtCore.Signal(int)
+    leverage_button_5_changed = QtCore.Signal(int)
+    leverage_button_6_changed = QtCore.Signal(int)
+    leverage_button_7_changed = QtCore.Signal(int)
     leverage_changed = QtCore.Signal()
 
     def __init__(self) -> None:
@@ -37,21 +48,46 @@ class _AppConfig(QtCore.QObject):
         self.trade_value_low = Decimal("25")
         self.trade_value_medium = Decimal("50")
         self.trade_value_high = Decimal("100")
+        self.leverage_button_1 = 2
+        self.leverage_button_2 = 5
+        self.leverage_button_3 = 10
+        self.leverage_button_4 = 20
+        self.leverage_button_5 = 25
+        self.leverage_button_6 = 50
+        self.leverage_button_7 = 100
         self.leverage = 5
+
+    @property
+    def leverage_button_values(self) -> list[int]:
+        return [
+            self.leverage_button_1,
+            self.leverage_button_2,
+            self.leverage_button_3,
+            self.leverage_button_4,
+            self.leverage_button_5,
+            self.leverage_button_6,
+            self.leverage_button_7,
+        ]
 
 
 class _ExchangeStub:
     """Minimal exchange surface consumed by PerpsTradeWidget."""
 
     quote_symbol: ClassVar[str] = "USDC"
-    max_leverage: ClassVar[int] = 50
-    available_pairs: ClassVar[set[str]] = {"Crypto.BTC/USDC"}
+    min_leverage: ClassVar[int] = 1
+    max_leverage: ClassVar[int] = 100
+    available_pairs: ClassVar[set[str]] = {"Crypto.BTC/USDC", "Crypto.ETH/USDC"}
     default_pair: ClassVar[str] = "Crypto.BTC/USDC"
     pair_prefix: ClassVar[str] = "Crypto."
     pair_suffix: ClassVar[str] = ""
     pair_separator: ClassVar[str] = "/"
+    pair_max_leverage: ClassVar[dict[str, int]] = {
+        "Crypto.BTC/USDC": _BTC_PAIR_MAX_LEVERAGE,
+        "Crypto.ETH/USDC": _ETH_PAIR_MAX_LEVERAGE,
+    }
     cached_prices: ClassVar[dict[str, dict[str, Decimal]]] = {
-        "Crypto.BTC/USDC": {"price": Decimal("97500")}
+        "Crypto.BTC/USDC": {"price": Decimal("97500")},
+        "Crypto.ETH/USDC": {"price": Decimal("3000")},
     }
     stable_balance: ClassVar[Decimal] = Decimal("100")
 
@@ -60,8 +96,12 @@ class _ExchangeStub:
         return pair.replace("Crypto.", "")
 
     @staticmethod
-    def format_coin_from_pair(_pair: str) -> str:
-        return "BTC"
+    def format_coin_from_pair(pair: str) -> str:
+        return pair.replace("Crypto.", "").split("/")[0]
+
+    @classmethod
+    def max_leverage_for_pair(cls, pair: str) -> int:
+        return cls.pair_max_leverage[pair]
 
     @staticmethod
     def calculate_margin_fee(_position_size: Decimal) -> Decimal:
@@ -83,6 +123,7 @@ class _UIControllerStub(QtCore.QObject):
         self.current_exchange = _ExchangeStub()
         self.app_config = _AppConfig()
         self.message_bus = _MessageBus()
+        self.current_pair = "Crypto.BTC/USDC"
 
     async def change_current_pair(self, _pair: str) -> None:
         """Satisfy the widget callback contract."""
@@ -141,3 +182,41 @@ class OrderlyTradeWidgetParityTests(unittest.TestCase):
             0.0,
             0.0,
         )
+
+    def test_pair_specific_leverage_cap_updates_when_selected_pair_changes(self) -> None:
+        """Refresh the leverage spin cap from the selected Orderly market metadata."""
+        # Arrange
+        ui_controller: Any = _UIControllerStub()
+        ui_controller.set_leverage = AsyncMock()
+        widget = PerpsTradeWidget(ui_controller)
+
+        # Assert initial pair cap
+        assert widget._leverage_spin.maximum() == _BTC_PAIR_MAX_LEVERAGE
+
+        # Act
+        event_loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(event_loop)
+            event_loop.run_until_complete(widget._controller.handle_pair_changed("Crypto.ETH/USDC"))
+        finally:
+            asyncio.set_event_loop(None)
+            event_loop.close()
+
+        # Assert
+        assert widget._leverage_spin.maximum() == _ETH_PAIR_MAX_LEVERAGE
+        ui_controller.set_leverage.assert_awaited_once_with("ETH", 5)
+
+    def test_leverage_quick_selection_includes_100x_button(self) -> None:
+        """Expose a 100x leverage shortcut in the trade widget."""
+        ui_controller: Any = _UIControllerStub()
+        widget = PerpsTradeWidget(ui_controller)
+
+        assert widget._leverage_group.button(100) is not None
+
+    def test_leverage_buttons_append_live_exchange_maximum(self) -> None:
+        """Expose the exchange max leverage button even when presets do not include it."""
+        ui_controller: Any = _UIControllerStub()
+        ui_controller.current_exchange.max_leverage = 125
+        widget = PerpsTradeWidget(ui_controller)
+
+        assert widget._leverage_group.button(125) is not None

--- a/tests/test_ui_pair_selection.py
+++ b/tests/test_ui_pair_selection.py
@@ -4,18 +4,23 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 import unittest
+from unittest.mock import AsyncMock, Mock, patch
 
 from PySide6 import QtCore, QtWidgets
 
 from plutus_terminal.controller.ui_controller import UIController
 from plutus_terminal.ui.widgets.news_widget import NewsWidget
+from plutus_terminal.ui.widgets.toast import ToastType
 
 if TYPE_CHECKING:
     from plutus_terminal.core.news.types import NewsData
+
+
+_ETH_PAIR_MAX_LEVERAGE = 20
 
 
 class _MessageBus(QtCore.QObject):
@@ -132,15 +137,47 @@ class UIControllerPairSelectionTests(unittest.IsolatedAsyncioTestCase):
         ]
         assert self.controller.current_pair == "Crypto.ETH/USDC"
 
+    async def test_set_leverage_warns_when_pair_change_clamps_above_pair_limit(self) -> None:
+        """Warn when a requested leverage is reduced to the selected pair maximum."""
+        self.controller.app_config = cast("Any", QtCore.QObject())
+        self.controller.app_config.leverage = 50
+
+        async def _set_leverage(_coin: str, leverage: int) -> None:
+            self.controller.app_config.leverage = min(leverage, _ETH_PAIR_MAX_LEVERAGE)
+
+        self.controller.current_exchange = cast(
+            "Any",
+            QtCore.QObject(),
+        )
+        self.controller.current_exchange.set_leverage = AsyncMock(side_effect=_set_leverage)
+        self.controller.current_exchange.min_leverage = 1
+        self.controller.current_exchange.max_leverage = 100
+        self.controller.current_exchange.max_leverage_for_pair = Mock(
+            return_value=_ETH_PAIR_MAX_LEVERAGE
+        )
+        self.controller.current_exchange.format_pair_from_coin = Mock(
+            return_value="Crypto.ETH/USDC"
+        )
+
+        with patch("plutus_terminal.controller.ui_controller.Toast.show_message") as show_message:
+            await self.controller.set_leverage("ETH", 50)
+
+        self.controller.current_exchange.set_leverage.assert_awaited_once_with("ETH", 50)
+        show_message.assert_called_once_with(
+            "Leverage of Crypto.ETH/USDC is too high. Set maximum leverage: 20x",
+            type_=ToastType.WARNING,
+        )
+        assert self.controller.app_config.leverage == _ETH_PAIR_MAX_LEVERAGE
+
     def test_optional_decimal_treats_blank_inputs_as_missing(self) -> None:
         """Ignore blank TP/SL inputs instead of attempting Decimal conversion."""
-        assert self.controller._optional_decimal(None) is None  # noqa: SLF001
-        assert self.controller._optional_decimal("") is None  # noqa: SLF001
-        assert self.controller._optional_decimal("   ") is None  # noqa: SLF001
+        assert self.controller._optional_decimal(None) is None
+        assert self.controller._optional_decimal("") is None
+        assert self.controller._optional_decimal("   ") is None
 
     def test_optional_decimal_strips_whitespace_for_numeric_inputs(self) -> None:
         """Trim optional numeric strings before converting them to Decimal."""
-        assert self.controller._optional_decimal(" 1.25 ") == Decimal("1.25")  # noqa: SLF001
+        assert self.controller._optional_decimal(" 1.25 ") == Decimal("1.25")
 
 
 class NewsWidgetPairSelectionTests(unittest.TestCase):

--- a/tests/ui/helpers.py
+++ b/tests/ui/helpers.py
@@ -67,6 +67,16 @@ class MessageBusStub(QtCore.QObject):
 class AppConfigStub(QtCore.QObject):
     """App-config stub with the signals and settings used by widgets."""
 
+    LEVERAGE_BUTTON_FIELDS = (
+        "leverage_button_1",
+        "leverage_button_2",
+        "leverage_button_3",
+        "leverage_button_4",
+        "leverage_button_5",
+        "leverage_button_6",
+        "leverage_button_7",
+    )
+
     leverage_changed = QtCore.Signal(int)
     stop_loss_changed = QtCore.Signal(float)
     take_profit_changed = QtCore.Signal(float)
@@ -74,6 +84,13 @@ class AppConfigStub(QtCore.QObject):
     trade_value_low_changed = QtCore.Signal(int)
     trade_value_medium_changed = QtCore.Signal(int)
     trade_value_high_changed = QtCore.Signal(int)
+    leverage_button_1_changed = QtCore.Signal(int)
+    leverage_button_2_changed = QtCore.Signal(int)
+    leverage_button_3_changed = QtCore.Signal(int)
+    leverage_button_4_changed = QtCore.Signal(int)
+    leverage_button_5_changed = QtCore.Signal(int)
+    leverage_button_6_changed = QtCore.Signal(int)
+    leverage_button_7_changed = QtCore.Signal(int)
     current_account_id_changed = QtCore.Signal(int)
     news_show_images_changed = QtCore.Signal(bool)
     news_desktop_notifications_changed = QtCore.Signal(bool)
@@ -92,6 +109,13 @@ class AppConfigStub(QtCore.QObject):
         self.trade_value_low = 25
         self.trade_value_medium = 50
         self.trade_value_high = 100
+        self.leverage_button_1 = 2
+        self.leverage_button_2 = 5
+        self.leverage_button_3 = 10
+        self.leverage_button_4 = 20
+        self.leverage_button_5 = 25
+        self.leverage_button_6 = 50
+        self.leverage_button_7 = 100
         self.leverage = 5
         self.current_account_id = 1
         self._settings = {
@@ -152,6 +176,11 @@ class AppConfigStub(QtCore.QObject):
 
     def load_all_configs(self) -> None:
         """Match the production config API."""
+
+    @property
+    def leverage_button_values(self) -> list[int]:
+        """Return configured leverage preset button values."""
+        return [getattr(self, field_name) for field_name in self.LEVERAGE_BUTTON_FIELDS]
 
 
 class PassGuardStub:
@@ -232,8 +261,12 @@ class ExchangeStub(QtCore.QObject):
         self.available_pairs = {pair, "Crypto.ETH/USDC"}
         self.default_pair = pair
         self.quote_symbol = "USDC"
-        self.max_leverage = 50
+        self.max_leverage = 100
         self.min_leverage = 1
+        self._pair_max_leverage = {
+            "Crypto.BTC/USDC": 25,
+            "Crypto.ETH/USDC": 50,
+        }
         self.pair_prefix = "Crypto."
         self.pair_separator = "/"
         self.pair_suffix = ""
@@ -270,6 +303,10 @@ class ExchangeStub(QtCore.QObject):
     def format_pair_from_coin(self, coin: str) -> str:
         """Build one exchange pair from a coin."""
         return f"Crypto.{coin}/USDC"
+
+    def max_leverage_for_pair(self, pair: str) -> int:
+        """Return the configured leverage cap for one pair."""
+        return self._pair_max_leverage.get(pair, self.max_leverage)
 
     def calculate_margin_fee(self, position_size: Decimal) -> Decimal:
         """Return a deterministic fee preview."""

--- a/tests/ui/test_widget_config.py
+++ b/tests/ui/test_widget_config.py
@@ -30,6 +30,10 @@ from tests.ui.helpers import AppConfigStub, UIControllerStub, ensure_app, proces
 
 ensure_app()
 
+_CUSTOM_LEVERAGE_BUTTON_1 = 3
+_CUSTOM_LEVERAGE_BUTTON_2 = 7
+_CUSTOM_LEVERAGE_BUTTON_7 = 90
+
 
 def _user_filter(*, filter_type: FilterType, action_type: ActionType) -> SimpleNamespace:
     """Create a lightweight user filter record."""
@@ -85,6 +89,59 @@ def test_perps_config_updates_trade_values_and_tp_sl() -> None:
     assert controller.app_config.take_profit == take_profit
     assert controller.app_config.stop_loss == stop_loss
     assert show_message.call_count == expected_call_count
+
+
+def test_perps_config_shows_current_pair_leverage_hint() -> None:
+    """PerpsConfig should display and refresh the selected pair leverage cap."""
+    controller = UIControllerStub()
+    widget = PerpsConfig(controller)
+
+    assert widget._pair_leverage_hint.text() == (
+        "Current pair max: BTC/USDC 25x. Each pair may use a different cap."
+    )
+
+    run_async(controller.change_current_pair, "Crypto.ETH/USDC")
+    process_events()
+
+    assert widget._pair_leverage_hint.text() == (
+        "Current pair max: ETH/USDC 50x. Each pair may use a different cap."
+    )
+
+
+def test_perps_config_exposes_100x_leverage_shortcut() -> None:
+    """PerpsConfig should offer a 100x preset leverage button."""
+    controller = UIControllerStub()
+    widget = PerpsConfig(controller)
+
+    assert widget._leverage_group.button(100) is not None
+
+
+def test_perps_config_updates_custom_leverage_button_values() -> None:
+    """PerpsConfig should persist user-defined leverage preset button values."""
+    controller = UIControllerStub()
+    widget = PerpsConfig(controller)
+
+    widget._leverage_button_spins[0].setValue(3)
+    widget._leverage_button_spins[1].setValue(7)
+    widget._leverage_button_spins[6].setValue(90)
+
+    with patch("plutus_terminal.ui.widgets.config.perps_config.Toast.show_message") as show_message:
+        widget._update_leverage_button_values()
+
+    assert controller.app_config.leverage_button_1 == _CUSTOM_LEVERAGE_BUTTON_1
+    assert controller.app_config.leverage_button_2 == _CUSTOM_LEVERAGE_BUTTON_2
+    assert controller.app_config.leverage_button_7 == _CUSTOM_LEVERAGE_BUTTON_7
+    assert widget._leverage_group.button(_CUSTOM_LEVERAGE_BUTTON_7) is not None
+    show_message.assert_called_once()
+
+
+def test_perps_config_appends_live_exchange_maximum_button() -> None:
+    """PerpsConfig should add the exchange max leverage button from API metadata."""
+    controller = UIControllerStub()
+    controller.current_exchange.max_leverage = 125
+    widget = PerpsConfig(controller)
+
+    assert widget._leverage_group.button(125) is not None
 
 
 def test_rpc_config_add_remove_and_write() -> None:


### PR DESCRIPTION
Use pair-specific Orderly leverage metadata, retry with the server-reported cap when stale limits are rejected, and clamp leverage on pair changes so leverage updates degrade to a warning instead of an uncaught error.

Persist configurable leverage preset buttons per account, append the live exchange max to the UI, and cover the new fallback and widget flows with regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-pair leverage limits: The app now enforces different maximum leverage caps for different trading pairs
  * Customizable leverage preset buttons: Users can configure the 7 leverage quick-select buttons via settings
  * Dynamic leverage caps: Leverage buttons automatically adjust based on exchange capabilities and pair limits

* **Bug Fixes**
  * Improved leverage validation with better error recovery when the server reports conflicting limits

* **Tests**
  * Enhanced test coverage for per-pair leverage handling and configuration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->