### PR TITLE
Fix generic new-account fields and picker dialog flow

### DIFF
--- a/plutus_terminal/core/exchange/orderly/exchange.py
+++ b/plutus_terminal/core/exchange/orderly/exchange.py
@@ -734,11 +734,18 @@ class OrderlyExchange(ExchangeBase):
         """Provide required secrets for account creation dialog."""
         return {
             "referral_link": None,
-            "secrets": [
-                "Orderly Account ID",
-                "Orderly API Key (orderly-key)",
-                "Orderly Secret",
-                "Network (mainnet|testnet)",
+            "fields": [
+                {"label": "Orderly Account ID"},
+                {"label": "Orderly API Key (orderly-key)"},
+                {"label": "Orderly Secret"},
+                {
+                    "label": "Network",
+                    "field_type": "select",
+                    "options": [
+                        {"label": "Mainnet", "value": OrderlyNetwork.MAINNET.value},
+                        {"label": "Testnet", "value": OrderlyNetwork.TESTNET.value},
+                    ],
+                },
             ],
         }
 

--- a/plutus_terminal/core/exchange/types.py
+++ b/plutus_terminal/core/exchange/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum, IntEnum
-from typing import TYPE_CHECKING, NotRequired, Optional, TypedDict
+from typing import TYPE_CHECKING, Literal, NotRequired, Optional, TypedDict
 
 from hexbytes import HexBytes
 
@@ -133,8 +133,26 @@ class OrderData(TypedDict):
     extra: NotRequired[dict]
 
 
+NewAccountFieldType = Literal["text", "select"]
+
+
+class NewAccountFieldOption(TypedDict):
+    """Selectable option for a new-account field."""
+
+    label: str
+    value: str
+
+
+class NewAccountField(TypedDict):
+    """Field definition for the new-account dialog."""
+
+    label: str
+    field_type: NotRequired[NewAccountFieldType]
+    options: NotRequired[list[NewAccountFieldOption]]
+
+
 class NewAccountInfo(TypedDict):
     """New account info."""
 
     referral_link: NotRequired[Optional[str]]
-    secrets: list[str]
+    fields: list[NewAccountField]

--- a/plutus_terminal/core/types_.py
+++ b/plutus_terminal/core/types_.py
@@ -2,6 +2,8 @@
 
 from .exchange.types import (
     ExchangeType,
+    NewAccountField,
+    NewAccountFieldOption,
     NewAccountInfo,
     PerpsPosition,
     PerpsTradeDirection,
@@ -18,6 +20,8 @@ __all__ = [
     "ExchangeType",
     "FilterType",
     "MessageLevel",
+    "NewAccountField",
+    "NewAccountFieldOption",
     "NewAccountInfo",
     "NewsData",
     "PerpsPosition",

--- a/plutus_terminal/ui/widgets/account_picker.py
+++ b/plutus_terminal/ui/widgets/account_picker.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Optional
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QComboBox, QWidget
-from qasync import asyncSlot
 
 from plutus_terminal.ui.widgets.new_account import NewAccountDialog
 
@@ -68,8 +67,7 @@ class AccountPicker(QComboBox):
                 self._current_index = index
                 break
 
-    @asyncSlot()
-    async def _on_account_changed(self, index: int) -> None:
+    def _on_account_changed(self, index: int) -> None:
         """Account changed."""
         account = self.itemData(index)
 

--- a/plutus_terminal/ui/widgets/new_account.py
+++ b/plutus_terminal/ui/widgets/new_account.py
@@ -10,7 +10,7 @@ from PySide6.QtGui import QPixmap, QRegularExpressionValidator
 
 from plutus_terminal.core import keyring_manager
 from plutus_terminal.core.exchange.valid_exchanges import VALID_EXCHANGES
-from plutus_terminal.core.types_ import ExchangeType
+from plutus_terminal.core.types_ import ExchangeType, NewAccountField
 from plutus_terminal.ui.widgets.toast import Toast, ToastType
 
 if TYPE_CHECKING:
@@ -48,7 +48,9 @@ class NewAccountDialog(QtWidgets.QDialog):
 
         self._secrets_group = QtWidgets.QGroupBox("Secrets:")
         self._secrets_layout = QtWidgets.QGridLayout()
+        self._secret_fields: list[NewAccountField] = []
         self._secrets_labels: list[QtWidgets.QLabel] = []
+        self._secret_inputs: list[QtWidgets.QLineEdit | QtWidgets.QComboBox] = []
         self._secrets_line_edits: list[QtWidgets.QLineEdit] = []
 
         self._log_label = QtWidgets.QLabel()
@@ -148,19 +150,44 @@ class NewAccountDialog(QtWidgets.QDialog):
             old_widget.deleteLater()
 
         self._secrets_labels.clear()
+        self._secret_fields.clear()
+        self._secret_inputs.clear()
         self._secrets_line_edits.clear()
 
         selected_exchange = self._exchange_combo_box.currentData()
         exchange = VALID_EXCHANGES[selected_exchange]
         new_account_info = exchange.new_account_info()
+        self._secret_fields.extend(new_account_info["fields"])
 
-        for secret in new_account_info["secrets"]:
-            label = QtWidgets.QLabel(secret)
-            line_edit = QtWidgets.QLineEdit()
+        for field in self._secret_fields:
+            label = QtWidgets.QLabel(field["label"])
+            input_widget = self._create_secret_input(field)
             self._secrets_layout.addWidget(label, len(self._secrets_labels), 0)
-            self._secrets_layout.addWidget(line_edit, len(self._secrets_labels), 1)
+            self._secrets_layout.addWidget(input_widget, len(self._secrets_labels), 1)
             self._secrets_labels.append(label)
-            self._secrets_line_edits.append(line_edit)
+            self._secret_inputs.append(input_widget)
+            if isinstance(input_widget, QtWidgets.QLineEdit):
+                self._secrets_line_edits.append(input_widget)
+
+    def _create_secret_input(
+        self,
+        field: NewAccountField,
+    ) -> QtWidgets.QLineEdit | QtWidgets.QComboBox:
+        """Create the appropriate input widget for a secret field."""
+        if field.get("field_type", "text") == "select":
+            combo_box = QtWidgets.QComboBox()
+            for option in field.get("options", []):
+                combo_box.addItem(option["label"], userData=option["value"])
+            return combo_box
+        return QtWidgets.QLineEdit()
+
+    @staticmethod
+    def _secret_value(secret_input: QtWidgets.QLineEdit | QtWidgets.QComboBox) -> str:
+        """Return the current value for a secret input widget."""
+        if isinstance(secret_input, QtWidgets.QComboBox):
+            current_value = secret_input.currentData()
+            return str(current_value) if current_value is not None else secret_input.currentText()
+        return secret_input.text()
 
     def _create_new_account(self) -> None:
         """Create new account on database."""
@@ -177,8 +204,8 @@ class NewAccountDialog(QtWidgets.QDialog):
                 ToastType.ERROR,
             )
             return
-        for line_edit in self._secrets_line_edits:
-            if not line_edit.text():
+        for secret_input in self._secret_inputs:
+            if not self._secret_value(secret_input):
                 self._log_label.setText("Secrets cannot be empty!")
                 Toast.update_message(
                     toast_id,
@@ -188,7 +215,7 @@ class NewAccountDialog(QtWidgets.QDialog):
                 return
 
         account_name = self._account_line_edit.text()
-        secrets = [secret.text() for secret in self._secrets_line_edits]
+        secrets = [self._secret_value(secret_input) for secret_input in self._secret_inputs]
         exchange_name = self._exchange_combo_box.currentData()
 
         # Validate secrets

--- a/tests/ui/test_widget_config.py
+++ b/tests/ui/test_widget_config.py
@@ -680,7 +680,13 @@ def test_new_account_dialog_creates_account_for_valid_exchange() -> None:
 
         @staticmethod
         def new_account_info() -> dict[str, object]:
-            return {"secrets": ["Account ID", "API Key", "Secret"]}
+            return {
+                "fields": [
+                    {"label": "Account ID"},
+                    {"label": "API Key"},
+                    {"label": "Secret"},
+                ]
+            }
 
         @staticmethod
         def validate_secrets(_secrets: list[str]) -> tuple[bool, str]:
@@ -709,6 +715,75 @@ def test_new_account_dialog_creates_account_for_valid_exchange() -> None:
     assert dialog.new_account is not None
     assert app_config.current_keyring_account.username == "orderly_test"
     set_password.assert_called_once()
+
+
+def test_new_account_dialog_uses_declared_select_field_values() -> None:
+    """NewAccountDialog should render generic select fields and store option values."""
+    app_config = AppConfigStub()
+    pass_guard = SimpleNamespace()
+    validated_secrets: list[str] = []
+
+    class _DummyExchange:
+        @staticmethod
+        def exchange_type() -> int:
+            return 0
+
+        @staticmethod
+        def name() -> str:
+            return "Custom"
+
+        @staticmethod
+        def new_account_info() -> dict[str, object]:
+            return {
+                "fields": [
+                    {"label": "API Key"},
+                    {"label": "API Secret"},
+                    {
+                        "label": "Environment",
+                        "field_type": "select",
+                        "options": [
+                            {"label": "Production", "value": "prod"},
+                            {"label": "Sandbox", "value": "sandbox"},
+                        ],
+                    },
+                ]
+            }
+
+        @staticmethod
+        def validate_secrets(secrets: list[str]) -> tuple[bool, str]:
+            validated_secrets[:] = secrets
+            return True, "ok"
+
+    with (
+        patch(
+            "plutus_terminal.ui.widgets.new_account.VALID_EXCHANGES",
+            {"custom": _DummyExchange},
+        ),
+        patch(
+            "plutus_terminal.ui.widgets.new_account.keyring_manager.set_exchange_password"
+        ) as set_password,
+        patch(
+            "plutus_terminal.ui.widgets.new_account.Toast.show_message",
+            return_value=b"toast-id",
+        ),
+        patch("plutus_terminal.ui.widgets.new_account.Toast.update_message"),
+    ):
+        dialog = NewAccountDialog(pass_guard, app_config)
+        dialog._account_line_edit.setText("custom_test")
+        for index, line_edit in enumerate(dialog._secrets_line_edits):
+            line_edit.setText(f"secret-{index}")
+
+        network_combo = dialog._secret_inputs[-1]
+        assert isinstance(network_combo, QtWidgets.QComboBox)
+        assert dialog._secrets_labels[-1].text() == "Environment"
+
+        network_combo.setCurrentIndex(1)
+        dialog._create_new_account()
+
+    assert validated_secrets == ["secret-0", "secret-1", "sandbox"]
+    assert set_password.call_args.args[0] == "custom_test"
+    assert set_password.call_args.args[1] == ["secret-0", "secret-1", "sandbox"]
+    assert set_password.call_args.args[2] is pass_guard
 
 
 def test_config_dialog_builds_expected_tabs() -> None:

--- a/tests/ui/test_widget_support.py
+++ b/tests/ui/test_widget_support.py
@@ -123,7 +123,7 @@ def test_account_picker_switches_to_selected_account() -> None:
     controller.app_config._accounts.append(second)
     picker = AccountPicker(controller)
 
-    run_async(picker._on_account_changed, 1)
+    picker._on_account_changed(1)
 
     assert controller.app_config.current_keyring_account == second
 
@@ -143,7 +143,7 @@ def test_account_picker_restores_previous_index_when_new_account_is_cancelled() 
         picker = AccountPicker(controller)
         original_index = picker.currentIndex()
 
-        run_async(picker._on_account_changed, picker.count() - 1)
+        picker._on_account_changed(picker.count() - 1)
 
     assert picker.currentIndex() == original_index
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account setup dialog now features structured input fields with proper labeling and dropdown menu support for configuration options
  * Network selection is now presented as a dropdown menu with dedicated Mainnet and Testnet options, improving user experience and reducing input errors
  * Exchange-provided field definitions now control input presentation for more flexible account configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->